### PR TITLE
FIX: Use correct event time in flyer, not time collect() is run.

### DIFF
--- a/profile_collection/startup/20-detectors.py
+++ b/profile_collection/startup/20-detectors.py
@@ -323,7 +323,7 @@ class AreaDetectorTimeseriesCollector:
         for v,t in zip(payload_val, payload_time):
             ev = {'data': {self._name: v},
                   'timestamps': {self._name: t},
-                  'time': ttime.time()}
+                  'time': t}
             yield ev
 
     def stop(self):


### PR DESCRIPTION
Today at the beamline, we discovered that `diag6_flyer1` was generating events with an `event.time` that corresponded to when the event documents were composed -- after the scan, during the `collect()` phase -- not when their respective data points were generated.

We worked around this by accessing `event.timestamps['diag6_flyer1']` instead of `event.time`. This PR makes `event.time` the same value as `event.timestamps['diag6_flyer1']`. Now `get_table` and other tools that use `event.time` will be usable on this data.
