### PR TITLE
CI: fix missing /nsls2/ dirs for continuous integration testing

### DIFF
--- a/.ci/bl-specific.sh
+++ b/.ci/bl-specific.sh
@@ -4,6 +4,6 @@
 # pip install <...>
 
 # Create non-standard directories:
-# sudo mkdir -v -p <...>
-# sudo chmod -Rv go+rw <...>
+sudo mkdir -v -p /nsls2/data/csx/shared/config/
+sudo chown -Rv $USER: /nsls2/
 


### PR DESCRIPTION
This update only affects the continuous integration setup for Azure Pipelines, it does not affect the production code.