### PR TITLE
Updated StandardAxisCam to use software trigger mode

### DIFF
--- a/startup/csx1/devices/areadetector.py
+++ b/startup/csx1/devices/areadetector.py
@@ -253,6 +253,7 @@ class AxisDetectorCam(AreaDetectorCam):
         # we should add more functionality to enable/disable triggering. if enabled, add atts
     )
     wait_for_plugins = Cpt(EpicsSignal, "WaitForPlugins", string=True, kind="hinted")
+    capture = Cpt(EpicsSignalWithRBV, "Capture", kind="omitted")
     gain = Cpt(EpicsSignalWithRBV, "GainMode", string=True, kind="config")
     prnu = Cpt(EpicsSignalWithRBV, "PRNU", string=True, kind="config")
     tec = Cpt(EpicsSignalWithRBV, "TEC", string=True, kind="config")
@@ -727,6 +728,7 @@ class ContinuousAxisCam(ContinuousAcquisitionTrigger, AxisCamBase):
 
         self._write_status: TriggerStatus | None = None
         self._num_triggered = 0
+        self._trigger_mode_switched = False
 
         self._default_plugin_graph = {
             self.cb: self.cam,


### PR DESCRIPTION
# Summary

This enables the use of software triggering mode for the `StandaradAxisCam`.

# How it works

Quick note: I use the term arm/disarm below to mean that we are starting/stopping capturing. I am not sure if my use of this word is correct in this context.

- When staging: Change trigger mode to "Software" and start capturing (effectively arming the detector).
- When triggering: Send one acquisition signal (acquire one or many frames in multiple image mode).
- When unstaging: Stop capturing (effectively disarming the detector).

# Example
```python
RE(count([axis_standard], num=5))
```
This triggers an acquisition 5 separate times. Currently, this arms and disarms the detector 5 times, one for each trigger. After this change, it will only arm and disarm once, during stage and unstage, respectively.